### PR TITLE
chore: prevent build&test run on main merges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,4 @@ jobs:
         run: yarn --ci
 
       - name: Build 👷‍♂️
-        # Set BASENAME if the static page is hosted under a specific path segment (e.g. elastic.github.io/kibana-release-notes)
-        # env:
-        #   BASENAME: kibana-release-notes
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build & Test
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Main pushes will trigger a different job, we can avoid double-building in these cases.