### PR TITLE
Remove breaking changes tags

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -233,12 +233,7 @@ For information about the {kib} {{version}} release, review the following inform
 Breaking changes can prevent your application from optimal operation and performance.
 Before you upgrade to {{version}}, review the breaking changes, then mitigate the impact to your application.
 
-// tag::notable-breaking-changes[]
-
 {{{prs.breaking}}}
-
-// end::notable-breaking-changes[]
-
 {{/prs.breaking}}
 {{#prs.deprecations}}
 [float]


### PR DESCRIPTION
With https://github.com/elastic/stack-docs/pull/2495 merged, we no longer need tags to reuse breaking changes in the Stack Install/Upgrade guide.

Relates to https://github.com/elastic/kibana/pull/162928