### PR TITLE
[Ops] Improve release notes

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -313,11 +313,11 @@ The {{version}} release includes the following bug fixes.
     prs: {
       breaking: `[discrete]
 [[breaking-{{number}}]]
-.{{{title}}}
+* {{{title}}}.
 [%collapsible]
 ====
 *Details* +
-!!TODO!! For more information, refer to {kibana-pull}{{number}}[#{{number}}]
+!!TODO!! For more information, refer to ({kibana-pull}{{number}}[#{{number}}]).
 
 *Impact* +
 !!TODO!!
@@ -325,18 +325,19 @@ The {{version}} release includes the following bug fixes.
       `,
       deprecation: `[discrete]
 [[deprecation-{{number}}]]
-.{{{title}}}
+* {{{title}}}.
 [%collapsible]
 ====
 *Details* +
-!!TODO!! For more information, refer to {kibana-pull}{{number}}[#{{number}}]
+!!TODO!! For more information, refer to ({kibana-pull}{{number}}[#{{number}}]).
 
 *Impact* +
 !!TODO!!
 ====
       `,
       _other_:
-        '* {{{title}}} {kibana-pull}{{number}}[#{{number}}]{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
+        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
     },
     prGroup: `{{{groupTitle}}}::\n{{{prs}}}`,
   },

--- a/src/config/templates/security.ts
+++ b/src/config/templates/security.ts
@@ -60,24 +60,32 @@ export const securityTemplate: Config = {
 
 [discrete]
 [[features-{{version}}]]
-==== Features
+==== New features
 {{{prs.features}}}
 {{/prs.features}}
-{{#prs.enhancementsAndFixes}}
+{{#prs.enhancements}}
+
+[discrete]
+[[enhancements-{{version}}]]
+==== Enhancements
+{{{prs.enhancements}}}
+{{/prs.enhancements}}
+{{#prs.fixes}}
 
 [discrete]
 [[bug-fixes-{{version}}]]
-==== Bug fixes and enhancements
-{{{prs.enhancementsAndFixes}}}
-{{/prs.enhancementsAndFixes}}
+==== Bug fixes
+{{{prs.fixes}}}
+{{/prs.fixes}}
+
 `,
     },
     prGroup: '{{{prs}}}',
     prs: {
-      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
-      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({pull}{{number}}[#{{number}}]) for details.\n`,
+      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({pull}{{number}}[#{{number}}]) for details.\n`,
       _other_:
-        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '* {{{title}}} ({pull}{{number}}[#{{number}}]).' +
         '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
     },
   },

--- a/src/config/templates/security.ts
+++ b/src/config/templates/security.ts
@@ -12,14 +12,20 @@ export const securityLabels = [
   'Team:Asset Management',
   'Team:Onboarding and Lifecycle Mgt',
   'Team:Security Solution Platform',
-  'Feature:Timeline',
-  'Feature:Detection Rules',
-  'Feature:Detection Alerts',
-  'Team:Detection Rules',
   'Team:Detection Alerts',
   'Team: CTI',
   'Team:CTI',
   'Team:Threat Hunting:Cases',
+  'Team:ResponseOps',
+  'Team:Cloud Security',
+  'Team:Detection Engine',
+  'Team:Defend Workflows',
+  'Team:Detection Rules',
+  'Feature:Timeline',
+  'Feature:Detection Rules',
+  'Feature:Detection Alerts',
+  'Feature:Entity Analytics',
+  'Feature:Rule Exceptions',
 ];
 
 export const securityTemplate: Config = {
@@ -68,10 +74,11 @@ export const securityTemplate: Config = {
     },
     prGroup: '{{{prs}}}',
     prs: {
-      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({pull}{{number}}[#{{number}}]) for details.\n`,
-      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({pull}{{number}}[#{{number}}]) for details.\n`,
+      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
       _other_:
-        '* {{{title}}} {pull}{{number}}[#{{number}}]{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
+        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
     },
   },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import { App } from './App';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { getBasename } from './config';
 
 import '@elastic/eui/dist/eui_theme_amsterdam_light.css';
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter basename={getBasename()}>
+    <HashRouter basename={getBasename()}>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/pages/release-notes/release-note-output.tsx
+++ b/src/pages/release-notes/release-note-output.tsx
@@ -40,12 +40,6 @@ export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
         config,
         version
       ),
-      enhancementsAndFixes: renderGroupedByArea(
-        groupByArea([...grouped.enhancements, ...grouped.fixes], config),
-        'enhancement',
-        config,
-        version
-      ),
       missingReleaseNoteLabel: grouped.missingLabel,
     };
   }, [config, prs, version]);


### PR DESCRIPTION
Closes: #163117 

---

Touching a few bits of the release-notes tool, mostly oriented towards the Security notes feature.
- Use hash router - this way, the urls will look like this: `https://release-notes.kibanateam.dev/#/release-notes`, and reloading the page will work. Currently it probably doesn't work because the app is hosted on a path on github pages.
- Add security related team labels from #163117
- Fix asciidoc output: separate fixes/enhancements, add punctuation