### PR TITLE
Security release note config file tweaks

### DIFF
--- a/src/config/templates/security.ts
+++ b/src/config/templates/security.ts
@@ -16,7 +16,6 @@ export const securityLabels = [
   'Team: CTI',
   'Team:CTI',
   'Team:Threat Hunting:Cases',
-  'Team:ResponseOps',
   'Team:Cloud Security',
   'Team:Detection Engine',
   'Team:Defend Workflows',
@@ -41,7 +40,7 @@ export const securityTemplate: Config = {
     pages: {
       releaseNotes: `[discrete]
 [[release-notes-{{version}}]]
-== {{version}}
+=== {{version}}
 {{#prs.breaking}}
 
 [discrete]


### PR DESCRIPTION
Making two minor adjustments:
-  Removed the `Team:ResponseOps` label since we don't need to track it for Security release notes. 
- Changed the header level for the version number from L2 to L3

