### PR TITLE
Map SLO feature to Observability title

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -176,8 +176,8 @@ export const kibanaTemplate: Config = {
       labels: ['Team:Code'],
     },
     {
-      title: 'Observability Home',
-      labels: ['Feature:Observability Home'],
+      title: 'Observability',
+      labels: ['Feature:Observability Home', 'Feature:SLO'],
     },
     {
       title: 'Infrastructure',


### PR DESCRIPTION
**Problem:** When we generate the Kibana release notes, PRs with the [`Feature:SLO`](https://github.com/elastic/kibana/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3AFeature%3ASLO) label are uncategorized.

**Solution:** Map the `Feature:SLO` and [`Observability:Home`](https://github.com/elastic/kibana/issues?q=is%3Aopen+label%3A%22Feature%3AObservability+Home%22+sort%3Aupdated-desc) labels to the **Observability** title in the Kibana release notes.