### PR TITLE
Use sentence case in "Bug fixes" title

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -299,7 +299,7 @@ For detailed information about the {{version}} release, review the enhancements 
 {{#prs.fixes}}
 [float]
 [[fixes-v{{version}}]]
-=== Bug Fixes
+=== Bug fixes
 {{{prs.fixes}}}
 {{/prs.fixes}}
       `,
@@ -318,7 +318,7 @@ The {{version}} release includes the following bug fixes.
 {{#prs.fixes}}
 [float]
 [[fixes-v{{version}}]]
-=== Bug Fixes
+=== Bug fixes
 {{{prs.fixes}}}
 {{/prs.fixes}}
       `,


### PR DESCRIPTION
**Problem:** The release notes template uses the "Bug Fixes" heading in title case. Elastic uses sentence case for headings.

**Solution:** Update template to use "Bug fixes" in sentence case.