### PR TITLE
Remove textOverwriteTemplate for security

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -166,10 +166,6 @@ export const kibanaTemplate: Config = {
     {
       title: 'Elastic Security',
       labels: securityLabels,
-      options: {
-        textOverwriteTemplate:
-          'For the Elastic Security {{version}} release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].',
-      },
     },
     {
       title: 'Code',


### PR DESCRIPTION
Closes [#elastic/kibana172270](https://github.com/elastic/kibana/issues/172270)

@leemthompo I left the textOverwriteTemplate functionality in place, but this was the last reference with it pointing to further release information.  I don't see any overwrites relating to enterprise search, not sure if that was an example.