### PR TITLE
Add support for non-Kibana and private repos

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,2 @@
 export const GITHUB_TOKEN = 'githubToken';
-export const KIBANA_REPO_ID = 7833168;
 export const GITHUB_OWNER = 'elastic';
-export const GITHUB_REPO = 'kibana';

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -44,6 +44,7 @@ function filterPrsForVersion(
 class GitHubService {
   private octokit: Octokit;
   private repoId: number | undefined;
+  public repoIsPrivate: boolean | undefined;
   public repoName: string;
 
   constructor(config: GitHubServiceConfig) {
@@ -59,6 +60,7 @@ class GitHubService {
         repo: this.repoName,
       });
       this.repoId = response.data.id;
+      this.repoIsPrivate = response.data.private;
     } catch (error) {
       console.error('Error fetching repository info:', error);
     }

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -103,7 +103,6 @@ class GitHubService {
    */
   private async getHighestVersionsForMajor(major: number, minorCount: number): Promise<string[]> {
     const allLabelsResponse = await this.octokit.search.labels({
-      // TODO: better undefined checking for repoId instead of casting
       repository_id: this.repoId as number,
       q: `v${major}.`,
       per_page: 100,
@@ -133,7 +132,6 @@ class GitHubService {
 
   private async getVersionsForMinor(major: number, minors: number[]): Promise<string[]> {
     const labelsResponse = await this.octokit.search.labels({
-      // TODO: better undefined checking for repoId instead of casting
       repository_id: this.repoId as number,
       q: minors.map((minor) => `v${major}.${minor}.`).join(' '),
       per_page: 100,

--- a/src/common/pr.tsx
+++ b/src/common/pr.tsx
@@ -11,52 +11,67 @@ interface PrProps {
   repoIsPrivate?: boolean;
 }
 
-export const Pr: FC<PrProps> = memo(
-  ({ pr, showAuthor, showTransformedTitle, normalizeOptions, repoIsPrivate }) => {
-    const title: ReleaseNoteDetails = showTransformedTitle
-      ? extractReleaseNotes(pr, normalizeOptions)
-      : { type: 'title', title: pr.title };
-    return (
-      <>
-        {title.title} (
-        {!repoIsPrivate && (
-          <EuiLink target="_blank" href={pr.html_url}>
-            #{pr.number}
-          </EuiLink>
-        )}{' '}
-        {showAuthor && (
-          <>
-            by <em>{pr.user?.login}</em>
-          </>
-        )}
-        ){' '}
-        {title.type === 'releaseNoteTitle' && (
-          <EuiIconTip
-            color="secondary"
-            type="iInCircle"
-            size="m"
-            content={
-              <>
-                This title was extracted from the PR description. Original PR title was:{' '}
-                <em>{title.originalTitle}</em>
-              </>
-            }
-          />
-        )}
-        {title.type === 'releaseNoteDetails' && (
-          <EuiIconTip
-            color="secondary"
-            type="visText"
-            size="m"
-            content={
-              <>
-                This PR had a lengthy release note description, that will be put into the release
-                notes and might need to be shortened.
-              </>
-            }
-          />
-        )}
-      </>
-    );
+const getLinkAndAuthor = (prProps: PrProps) => {
+  const { pr, showAuthor, repoIsPrivate } = prProps;
+
+  if (repoIsPrivate && !showAuthor) {
+    return '';
   }
-);
+
+  return (
+    <>
+      {' ('}
+      {!repoIsPrivate && (
+        <EuiLink target="_blank" href={pr.html_url}>
+          {`#${pr.number}`}
+        </EuiLink>
+      )}
+      {showAuthor && (
+        <>
+          {`${repoIsPrivate ? '' : ' '}by `}
+          <em>{pr.user?.login}</em>
+        </>
+      )}
+      {')'}
+    </>
+  );
+};
+
+export const Pr: FC<PrProps> = memo((props) => {
+  const { pr, showTransformedTitle, normalizeOptions } = props;
+  const title: ReleaseNoteDetails = showTransformedTitle
+    ? extractReleaseNotes(pr, normalizeOptions)
+    : { type: 'title', title: pr.title };
+  return (
+    <>
+      {title.title}
+      {getLinkAndAuthor(props)}
+      {title.type === 'releaseNoteTitle' && (
+        <EuiIconTip
+          color="secondary"
+          type="iInCircle"
+          size="m"
+          content={
+            <>
+              This title was extracted from the PR description. Original PR title was:{' '}
+              <em>{title.originalTitle}</em>
+            </>
+          }
+        />
+      )}
+      {title.type === 'releaseNoteDetails' && (
+        <EuiIconTip
+          color="secondary"
+          type="visText"
+          size="m"
+          content={
+            <>
+              This PR had a lengthy release note description, that will be put into the release
+              notes and might need to be shortened.
+            </>
+          }
+        />
+      )}
+    </>
+  );
+});

--- a/src/common/pr.tsx
+++ b/src/common/pr.tsx
@@ -8,19 +8,22 @@ interface PrProps {
   showAuthor?: boolean;
   showTransformedTitle?: boolean;
   normalizeOptions?: NormalizeOptions;
+  repoIsPrivate?: boolean;
 }
 
 export const Pr: FC<PrProps> = memo(
-  ({ pr, showAuthor, showTransformedTitle, normalizeOptions }) => {
+  ({ pr, showAuthor, showTransformedTitle, normalizeOptions, repoIsPrivate }) => {
     const title: ReleaseNoteDetails = showTransformedTitle
       ? extractReleaseNotes(pr, normalizeOptions)
       : { type: 'title', title: pr.title };
     return (
       <>
         {title.title} (
-        <EuiLink target="_blank" href={pr.html_url}>
-          #{pr.number}
-        </EuiLink>{' '}
+        {!repoIsPrivate && (
+          <EuiLink target="_blank" href={pr.html_url}>
+            #{pr.number}
+          </EuiLink>
+        )}{' '}
         {showAuthor && (
           <>
             by <em>{pr.user?.login}</em>

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -1,0 +1,89 @@
+import type { Config } from './types';
+
+export const endpointLabels = [
+  'feature:hostisolation',
+  'feature:memoryscan',
+  'feature:harden',
+  'feature:memoryprotection',
+  'feature:comms',
+  'feature:performance',
+  'feature:malware',
+  'feature:events',
+  'feature:install',
+  'feature:policy',
+  'feature:ransomware',
+  'feature:security',
+  'feature:testing',
+  'feature:rules',
+  'feature:ASR',
+  'feature:shipper',
+  'feature:code_quality',
+  'feature:false-positives',
+  'feature:filescore',
+  'feature:telemetry',
+  'feature:agentintegration',
+  'feature:user_experience',
+];
+
+export const endpointTemplate: Config = {
+  includedLabels: endpointLabels,
+  excludedLabels: ['backport', 'release_note:skip'],
+  areas: [
+    {
+      title: 'Elastic Endpoint',
+      labels: endpointLabels,
+    },
+  ],
+  templates: {
+    pages: {
+      releaseNotes: `[discrete]
+[[release-notes-{{version}}]]
+=== {{version}}
+{{#prs.breaking}}
+
+[discrete]
+[[breaking-changes-{{version}}]]
+==== Breaking changes
+{{{prs.breaking}}}
+{{/prs.breaking}}
+{{#prs.deprecations}}
+
+[discrete]
+[[deprecations-{{version}}]]
+==== Deprecations
+{{{prs.deprecations}}}
+{{/prs.deprecations}}
+{{#prs.features}}
+
+[discrete]
+[[features-{{version}}]]
+==== New features
+{{{prs.features}}}
+{{/prs.features}}
+{{#prs.enhancements}}
+
+[discrete]
+[[enhancements-{{version}}]]
+==== Enhancements
+{{{prs.enhancements}}}
+{{/prs.enhancements}}
+{{#prs.fixes}}
+
+[discrete]
+[[bug-fixes-{{version}}]]
+==== Bug fixes
+{{{prs.fixes}}}
+{{/prs.fixes}}
+
+`,
+    },
+    prGroup: '{{{prs}}}',
+    prs: {
+      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      _other_:
+        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
+    },
+  },
+};

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -26,6 +26,7 @@ export const endpointLabels = [
 ];
 
 export const endpointTemplate: Config = {
+  repoName: 'endpoint-dev',
   includedLabels: endpointLabels,
   excludedLabels: ['backport', 'release_note:skip'],
   areas: [

--- a/src/config/templates/index.ts
+++ b/src/config/templates/index.ts
@@ -1,19 +1,22 @@
 import { kibanaTemplate } from './kibana';
 import { securityTemplate } from './security';
+import { endpointTemplate } from './endpoint';
 import { Config } from './types';
+import type { EuiIconProps } from '@elastic/eui';
 
 export * from './types';
 
-export type TemplateId = 'kibana' | 'security';
+export type TemplateId = 'kibana' | 'security' | 'endpoint';
 
 export interface TemplateInfo {
   id: TemplateId;
   name: string;
-  icon: string;
+  icon: EuiIconProps['type'];
   config: Config;
 }
 
 export const templates: TemplateInfo[] = [
   { id: 'kibana', name: 'Kibana', icon: 'logoKibana', config: kibanaTemplate },
   { id: 'security', name: 'Security', icon: 'logoSecurity', config: securityTemplate },
+  { id: 'endpoint', name: 'Endpoint', icon: 'logoElastic', config: endpointTemplate },
 ];

--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -2,6 +2,7 @@ import type { Config } from './types';
 import { securityLabels } from './security';
 
 export const kibanaTemplate: Config = {
+  repoName: 'kibana',
   excludedLabels: ['release_note:skip', 'Team:Docs', 'reverted', 'backport'],
   areas: [
     {

--- a/src/config/templates/security.ts
+++ b/src/config/templates/security.ts
@@ -28,6 +28,7 @@ export const securityLabels = [
 ];
 
 export const securityTemplate: Config = {
+  repoName: 'kibana',
   includedLabels: securityLabels,
   excludedLabels: ['backport', 'release_note:skip'],
   areas: [

--- a/src/config/templates/types.ts
+++ b/src/config/templates/types.ts
@@ -34,4 +34,5 @@ export interface Config {
     };
     prGroup: string;
   };
+  repoName: string;
 }

--- a/src/pages/github/github.tsx
+++ b/src/pages/github/github.tsx
@@ -65,7 +65,7 @@ const stateMachine = Machine<Context, StateSchema, Events>(
             {
               target: 'error.invalidScope',
               cond: (context, event: DoneInvokeEvent<TokenValidated>) =>
-                !event.data.scopes.includes('public_repo'),
+                !event.data.scopes.includes('repo'),
             },
             {
               target: 'success',
@@ -182,8 +182,9 @@ export const GitHubSettings: FC = () => {
             <EuiLink href="https://github.com/settings/tokens" target="_blank">
               GitHub
             </EuiLink>{' '}
-            and click <em>Generate new token</em>. The token must have <strong>only</strong> the{' '}
-            <EuiCode>public_repo</EuiCode> permission.
+            and click <em>Generate new token</em>. The token must have the{' '}
+            <EuiCode>public_repo</EuiCode> permission for public repos and the full{' '}
+            <EuiCode>repo</EuiCode> scope for private repos.
           </p>
           <p>
             Enable SSO for this token after creating it by clicking <em>Configure SSO</em> in the
@@ -213,7 +214,7 @@ export const GitHubSettings: FC = () => {
           )}
           {current.matches('error.invalidScope') && (
             <EuiTextColor color="danger">
-              Your token is missing the <EuiCode>public_repo</EuiCode> permission.
+              Your token is missing the <EuiCode>repo</EuiCode> permission.
             </EuiTextColor>
           )}
         </EuiText>

--- a/src/pages/release-notes/components/grouped-pr-list.tsx
+++ b/src/pages/release-notes/components/grouped-pr-list.tsx
@@ -7,9 +7,10 @@ interface Props {
   groupedPrs: { [group: string]: PrItem[] };
   groups: Config['areas'];
   keyPrefix: string;
+  repoIsPrivate: boolean | undefined;
 }
 
-export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix }) => {
+export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix, repoIsPrivate }) => {
   const sortedGroups = useMemo(
     () => [...groups].sort((a, b) => a.title.localeCompare(b.title)),
     [groups]
@@ -37,7 +38,12 @@ export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix })
             <ul>
               {prs.map((pr) => (
                 <li key={pr.id}>
-                  <Pr pr={pr} showTransformedTitle={true} normalizeOptions={group.options} />
+                  <Pr
+                    pr={pr}
+                    showTransformedTitle={true}
+                    normalizeOptions={group.options}
+                    repoIsPrivate={repoIsPrivate}
+                  />
                 </li>
               ))}
             </ul>

--- a/src/pages/release-notes/components/uncategorized-pr.tsx
+++ b/src/pages/release-notes/components/uncategorized-pr.tsx
@@ -17,6 +17,7 @@ import { setConfig, useActiveConfig } from '../../../config';
 
 interface UncategorizedPrProps {
   pr: PrItem;
+  repoIsPrivate: boolean | undefined;
 }
 
 const LabelBadge: FC<{ label: Label }> = memo(({ label }) => {
@@ -83,7 +84,7 @@ const LabelBadge: FC<{ label: Label }> = memo(({ label }) => {
   );
 });
 
-export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr }) => {
+export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr, repoIsPrivate }) => {
   // We only want to show non version non release_note labels in the UI
   const filteredLables = useMemo(
     () =>
@@ -95,7 +96,7 @@ export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr }) => {
   return (
     <EuiSplitPanel.Outer>
       <EuiSplitPanel.Inner paddingSize="s">
-        <Pr pr={pr} showAuthor={true} />
+        <Pr pr={pr} showAuthor={true} repoIsPrivate={repoIsPrivate} />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
         {filteredLables.length > 0 && (

--- a/src/pages/release-notes/prepare-release-notes.tsx
+++ b/src/pages/release-notes/prepare-release-notes.tsx
@@ -7,9 +7,10 @@ import { GroupedPrList, UncategorizedPr } from './components';
 
 interface Props {
   prs: PrItem[];
+  repoIsPrivate: boolean | undefined;
 }
 
-export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
+export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
   const config = useActiveConfig();
   const groupedPrs = useMemo(() => groupPrs(prs), [prs]);
 
@@ -49,7 +50,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <ul>
             {groupedPrs.missingLabel.map((pr) => (
               <li key={pr.id}>
-                <Pr pr={pr} showAuthor={true} />
+                <Pr pr={pr} showAuthor={true} repoIsPrivate={repoIsPrivate} />
               </li>
             ))}
           </ul>
@@ -73,7 +74,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <EuiSpacer size="m" />
           {unknownPrs.map((pr) => (
             <React.Fragment key={pr.id}>
-              <UncategorizedPr pr={pr} />
+              <UncategorizedPr pr={pr} repoIsPrivate={repoIsPrivate} />
               <EuiSpacer size="s" />
             </React.Fragment>
           ))}
@@ -87,7 +88,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <ul>
             {groupedPrs.breaking.map((pr) => (
               <li key={`breaking-${pr.id}`}>
-                <Pr pr={pr} showTransformedTitle={true} />
+                <Pr pr={pr} showTransformedTitle={true} repoIsPrivate={repoIsPrivate} />
               </li>
             ))}
           </ul>
@@ -101,7 +102,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <ul>
             {groupedPrs.deprecation.map((pr) => (
               <li key={`deprecation-${pr.id}`}>
-                <Pr pr={pr} showTransformedTitle={true} />
+                <Pr pr={pr} showTransformedTitle={true} repoIsPrivate={repoIsPrivate} />
               </li>
             ))}
           </ul>
@@ -112,7 +113,12 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <h2>
             Features (<EuiCode>release_note:feature</EuiCode>)
           </h2>
-          <GroupedPrList groupedPrs={featurePrs} groups={config.areas} keyPrefix="features" />
+          <GroupedPrList
+            groupedPrs={featurePrs}
+            groups={config.areas}
+            keyPrefix="features"
+            repoIsPrivate={repoIsPrivate}
+          />
         </>
       )}
       {Object.keys(enhancementPrs).length > 0 && (
@@ -124,6 +130,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
             groupedPrs={enhancementPrs}
             groups={config.areas}
             keyPrefix="enhancements"
+            repoIsPrivate={repoIsPrivate}
           />
         </>
       )}
@@ -132,7 +139,12 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
           <h2>
             Bug fixes (<EuiCode>release_note:fix</EuiCode>)
           </h2>
-          <GroupedPrList groupedPrs={fixesPr} groups={config.areas} keyPrefix="fixes" />
+          <GroupedPrList
+            groupedPrs={fixesPr}
+            groups={config.areas}
+            keyPrefix="fixes"
+            repoIsPrivate={repoIsPrivate}
+          />
         </>
       )}
     </EuiText>

--- a/src/pages/release-notes/release-notes.tsx
+++ b/src/pages/release-notes/release-notes.tsx
@@ -146,7 +146,7 @@ export const ReleaseNotes: FC<Props> = ({ version, onVersionChange, ignoredPrior
             </>
           )}
           {step === 'prepare' ? (
-            <PrepareReleaseNotes prs={prs} />
+            <PrepareReleaseNotes prs={prs} repoIsPrivate={github.repoIsPrivate} />
           ) : (
             <ReleaseNoteOutput prs={prs} version={version} />
           )}


### PR DESCRIPTION
## Summary

Closes elastic/kibana-operations#132

This PR adds support for generating release notes for repos that are not Kibana, as well as private repos. It also adds a base template for Endpoint repo.

### Testing
0. Clone repo and `yarn install` if needed
1. Pull the branch
2. Generate a token with full repo scope and configure SSO: https://github.com/settings/tokens
3. Complete the setup
4. `Release Notes` in the header to use wizard to generate notes