### PR TITLE
Fix PR Links and Duplicate PRs in Features and Enhancements

### DIFF
--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -44,7 +44,6 @@ function filterPrsForVersion(
 class GitHubService {
   private octokit: Octokit;
   private repoId: number | undefined;
-  public repoIsPrivate: boolean | undefined;
   public repoName: string;
 
   constructor(config: GitHubServiceConfig) {
@@ -60,7 +59,6 @@ class GitHubService {
         repo: this.repoName,
       });
       this.repoId = response.data.id;
-      this.repoIsPrivate = response.data.private;
     } catch (error) {
       console.error('Error fetching repository info:', error);
     }

--- a/src/common/pr-utils/grouping.ts
+++ b/src/common/pr-utils/grouping.ts
@@ -73,20 +73,6 @@ export function groupPrs(prs: PrItem[], options: GroupPrOptions = {}): ReleaseNo
             break;
           case 'release_note:feature':
             groups.features.push(pr);
-            // We treat the feature label slightly different, so that it will be also grouped
-            // into the enhancement category (for the "all changes list", that doesn't list
-            // features), unless it also has another release_note label on it that will then define
-            // its group.
-            if (
-              options.includeFeaturesInEnhancements &&
-              // Check if there's any release_note: label other than release_note:feature
-              !pr.labels.some(
-                ({ name }) =>
-                  name && name.startsWith('release_note:') && name !== 'release_note:feature'
-              )
-            ) {
-              groups.enhancements.push(pr);
-            }
             break;
         }
       }

--- a/src/common/pr.tsx
+++ b/src/common/pr.tsx
@@ -11,67 +11,52 @@ interface PrProps {
   repoIsPrivate?: boolean;
 }
 
-const getLinkAndAuthor = (prProps: PrProps) => {
-  const { pr, showAuthor, repoIsPrivate } = prProps;
-
-  if (repoIsPrivate && !showAuthor) {
-    return '';
+export const Pr: FC<PrProps> = memo(
+  ({ pr, showAuthor, showTransformedTitle, normalizeOptions, repoIsPrivate }) => {
+    const title: ReleaseNoteDetails = showTransformedTitle
+      ? extractReleaseNotes(pr, normalizeOptions)
+      : { type: 'title', title: pr.title };
+    return (
+      <>
+        {title.title} (
+        {!repoIsPrivate && (
+          <EuiLink target="_blank" href={pr.html_url}>
+            #{pr.number}
+          </EuiLink>
+        )}{' '}
+        {showAuthor && (
+          <>
+            by <em>{pr.user?.login}</em>
+          </>
+        )}
+        ){' '}
+        {title.type === 'releaseNoteTitle' && (
+          <EuiIconTip
+            color="secondary"
+            type="iInCircle"
+            size="m"
+            content={
+              <>
+                This title was extracted from the PR description. Original PR title was:{' '}
+                <em>{title.originalTitle}</em>
+              </>
+            }
+          />
+        )}
+        {title.type === 'releaseNoteDetails' && (
+          <EuiIconTip
+            color="secondary"
+            type="visText"
+            size="m"
+            content={
+              <>
+                This PR had a lengthy release note description, that will be put into the release
+                notes and might need to be shortened.
+              </>
+            }
+          />
+        )}
+      </>
+    );
   }
-
-  return (
-    <>
-      {' ('}
-      {!repoIsPrivate && (
-        <EuiLink target="_blank" href={pr.html_url}>
-          {`#${pr.number}`}
-        </EuiLink>
-      )}
-      {showAuthor && (
-        <>
-          {`${repoIsPrivate ? '' : ' '}by `}
-          <em>{pr.user?.login}</em>
-        </>
-      )}
-      {')'}
-    </>
-  );
-};
-
-export const Pr: FC<PrProps> = memo((props) => {
-  const { pr, showTransformedTitle, normalizeOptions } = props;
-  const title: ReleaseNoteDetails = showTransformedTitle
-    ? extractReleaseNotes(pr, normalizeOptions)
-    : { type: 'title', title: pr.title };
-  return (
-    <>
-      {title.title}
-      {getLinkAndAuthor(props)}
-      {title.type === 'releaseNoteTitle' && (
-        <EuiIconTip
-          color="secondary"
-          type="iInCircle"
-          size="m"
-          content={
-            <>
-              This title was extracted from the PR description. Original PR title was:{' '}
-              <em>{title.originalTitle}</em>
-            </>
-          }
-        />
-      )}
-      {title.type === 'releaseNoteDetails' && (
-        <EuiIconTip
-          color="secondary"
-          type="visText"
-          size="m"
-          content={
-            <>
-              This PR had a lengthy release note description, that will be put into the release
-              notes and might need to be shortened.
-            </>
-          }
-        />
-      )}
-    </>
-  );
-});
+);

--- a/src/common/pr.tsx
+++ b/src/common/pr.tsx
@@ -8,22 +8,19 @@ interface PrProps {
   showAuthor?: boolean;
   showTransformedTitle?: boolean;
   normalizeOptions?: NormalizeOptions;
-  repoIsPrivate?: boolean;
 }
 
 export const Pr: FC<PrProps> = memo(
-  ({ pr, showAuthor, showTransformedTitle, normalizeOptions, repoIsPrivate }) => {
+  ({ pr, showAuthor, showTransformedTitle, normalizeOptions }) => {
     const title: ReleaseNoteDetails = showTransformedTitle
       ? extractReleaseNotes(pr, normalizeOptions)
       : { type: 'title', title: pr.title };
     return (
       <>
         {title.title} (
-        {!repoIsPrivate && (
-          <EuiLink target="_blank" href={pr.html_url}>
-            #{pr.number}
-          </EuiLink>
-        )}{' '}
+        <EuiLink target="_blank" href={pr.html_url}>
+          #{pr.number}
+        </EuiLink>{' '}
         {showAuthor && (
           <>
             by <em>{pr.user?.login}</em>

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -80,10 +80,10 @@ export const endpointTemplate: Config = {
     },
     prGroup: '{{{prs}}}',
     prs: {
-      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
-      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      breaking: `*{{{title}}}*\n\n!!TODO!!\n`,
+      deprecation: `*{{{title}}}*\n\n!!TODO!!\n`,
       _other_:
-        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '* {{{title}}}.' +
         '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
     },
   },

--- a/src/pages/release-notes/components/grouped-pr-list.tsx
+++ b/src/pages/release-notes/components/grouped-pr-list.tsx
@@ -7,10 +7,9 @@ interface Props {
   groupedPrs: { [group: string]: PrItem[] };
   groups: Config['areas'];
   keyPrefix: string;
-  repoIsPrivate: boolean | undefined;
 }
 
-export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix, repoIsPrivate }) => {
+export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix }) => {
   const sortedGroups = useMemo(
     () => [...groups].sort((a, b) => a.title.localeCompare(b.title)),
     [groups]
@@ -38,12 +37,7 @@ export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix, r
             <ul>
               {prs.map((pr) => (
                 <li key={pr.id}>
-                  <Pr
-                    pr={pr}
-                    showTransformedTitle={true}
-                    normalizeOptions={group.options}
-                    repoIsPrivate={repoIsPrivate}
-                  />
+                  <Pr pr={pr} showTransformedTitle={true} normalizeOptions={group.options} />
                 </li>
               ))}
             </ul>

--- a/src/pages/release-notes/components/uncategorized-pr.tsx
+++ b/src/pages/release-notes/components/uncategorized-pr.tsx
@@ -17,7 +17,6 @@ import { setConfig, useActiveConfig } from '../../../config';
 
 interface UncategorizedPrProps {
   pr: PrItem;
-  repoIsPrivate: boolean | undefined;
 }
 
 const LabelBadge: FC<{ label: Label }> = memo(({ label }) => {
@@ -84,7 +83,7 @@ const LabelBadge: FC<{ label: Label }> = memo(({ label }) => {
   );
 });
 
-export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr, repoIsPrivate }) => {
+export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr }) => {
   // We only want to show non version non release_note labels in the UI
   const filteredLables = useMemo(
     () =>
@@ -96,7 +95,7 @@ export const UncategorizedPr: FC<UncategorizedPrProps> = memo(({ pr, repoIsPriva
   return (
     <EuiSplitPanel.Outer>
       <EuiSplitPanel.Inner paddingSize="s">
-        <Pr pr={pr} showAuthor={true} repoIsPrivate={repoIsPrivate} />
+        <Pr pr={pr} showAuthor={true} />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
         {filteredLables.length > 0 && (

--- a/src/pages/release-notes/prepare-release-notes.tsx
+++ b/src/pages/release-notes/prepare-release-notes.tsx
@@ -7,10 +7,9 @@ import { GroupedPrList, UncategorizedPr } from './components';
 
 interface Props {
   prs: PrItem[];
-  repoIsPrivate: boolean | undefined;
 }
 
-export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
+export const PrepareReleaseNotes: FC<Props> = ({ prs }) => {
   const config = useActiveConfig();
   const groupedPrs = useMemo(() => groupPrs(prs), [prs]);
 
@@ -50,7 +49,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <ul>
             {groupedPrs.missingLabel.map((pr) => (
               <li key={pr.id}>
-                <Pr pr={pr} showAuthor={true} repoIsPrivate={repoIsPrivate} />
+                <Pr pr={pr} showAuthor={true} />
               </li>
             ))}
           </ul>
@@ -74,7 +73,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <EuiSpacer size="m" />
           {unknownPrs.map((pr) => (
             <React.Fragment key={pr.id}>
-              <UncategorizedPr pr={pr} repoIsPrivate={repoIsPrivate} />
+              <UncategorizedPr pr={pr} />
               <EuiSpacer size="s" />
             </React.Fragment>
           ))}
@@ -88,7 +87,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <ul>
             {groupedPrs.breaking.map((pr) => (
               <li key={`breaking-${pr.id}`}>
-                <Pr pr={pr} showTransformedTitle={true} repoIsPrivate={repoIsPrivate} />
+                <Pr pr={pr} showTransformedTitle={true} />
               </li>
             ))}
           </ul>
@@ -102,7 +101,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <ul>
             {groupedPrs.deprecation.map((pr) => (
               <li key={`deprecation-${pr.id}`}>
-                <Pr pr={pr} showTransformedTitle={true} repoIsPrivate={repoIsPrivate} />
+                <Pr pr={pr} showTransformedTitle={true} />
               </li>
             ))}
           </ul>
@@ -113,12 +112,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <h2>
             Features (<EuiCode>release_note:feature</EuiCode>)
           </h2>
-          <GroupedPrList
-            groupedPrs={featurePrs}
-            groups={config.areas}
-            keyPrefix="features"
-            repoIsPrivate={repoIsPrivate}
-          />
+          <GroupedPrList groupedPrs={featurePrs} groups={config.areas} keyPrefix="features" />
         </>
       )}
       {Object.keys(enhancementPrs).length > 0 && (
@@ -130,7 +124,6 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
             groupedPrs={enhancementPrs}
             groups={config.areas}
             keyPrefix="enhancements"
-            repoIsPrivate={repoIsPrivate}
           />
         </>
       )}
@@ -139,12 +132,7 @@ export const PrepareReleaseNotes: FC<Props> = ({ prs, repoIsPrivate }) => {
           <h2>
             Bug fixes (<EuiCode>release_note:fix</EuiCode>)
           </h2>
-          <GroupedPrList
-            groupedPrs={fixesPr}
-            groups={config.areas}
-            keyPrefix="fixes"
-            repoIsPrivate={repoIsPrivate}
-          />
+          <GroupedPrList groupedPrs={fixesPr} groups={config.areas} keyPrefix="fixes" />
         </>
       )}
     </EuiText>

--- a/src/pages/release-notes/release-notes.tsx
+++ b/src/pages/release-notes/release-notes.tsx
@@ -146,7 +146,7 @@ export const ReleaseNotes: FC<Props> = ({ version, onVersionChange, ignoredPrior
             </>
           )}
           {step === 'prepare' ? (
-            <PrepareReleaseNotes prs={prs} repoIsPrivate={github.repoIsPrivate} />
+            <PrepareReleaseNotes prs={prs} />
           ) : (
             <ReleaseNoteOutput prs={prs} version={version} />
           )}


### PR DESCRIPTION
Closes #20
Closes #18 (a bug added in #14)

Generated notes for Endpoint now have the link removed since it is a private repo:

```
[discrete]
[[release-notes-8.16.0]]
=== 8.16.0

[discrete]
[[features-8.16.0]]
==== New features
* ETW Security Auditing Part I.

[discrete]
[[enhancements-8.16.0]]
==== Enhancements
* ETW Security Auditing Part I.
```

Reverts 9603d78 and 31651ff to add the links back to release note preview on private repos:

![image](https://github.com/user-attachments/assets/d59cde67-1685-453a-99d2-89ad8ab42bd0)