### PR TITLE
Fix prepare release notes for Endpoint

### DIFF
--- a/src/common/pr-utils/grouping.ts
+++ b/src/common/pr-utils/grouping.ts
@@ -1,5 +1,6 @@
 import { PrItem } from '../../common';
 import { Config } from '../../config';
+import { AreaDefinition } from '../../config/templates';
 
 export interface ReleaseNoteGroups<T> {
   fixes: T;
@@ -21,9 +22,14 @@ export function groupByArea(prs: PrItem[], { areas }: Config): GroupedByArea {
   // TODO: How to handle/track PRs in multiple areas.
   const grouped = prs.reduce<{ unknown: PrItem[]; areas: { [title: string]: PrItem[] } }>(
     (grouped, pr) => {
-      const matchingAreas = areas.filter(
-        ({ labels }) => labels && pr.labels.some(({ name }) => name && labels.includes(name))
-      );
+      let matchingAreas: AreaDefinition[] = [];
+      if (!areas || areas.length === 0) {
+        matchingAreas = [{ title: '', labels: [] }];
+      } else {
+        matchingAreas = areas.filter(
+          ({ labels }) => labels && pr.labels.some(({ name }) => name && labels.includes(name))
+        );
+      }
 
       if (matchingAreas.length === 0) {
         grouped.unknown.push(pr);

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -3,11 +3,7 @@ import type { Config } from './types';
 export const endpointTemplate: Config = {
   repoName: 'endpoint-dev',
   excludedLabels: ['backport', 'release_note:skip'],
-  areas: [
-    {
-      title: 'Elastic Endpoint',
-    },
-  ],
+  areas: [],
   templates: {
     pages: {
       releaseNotes: `[discrete]

--- a/src/config/templates/types.ts
+++ b/src/config/templates/types.ts
@@ -1,4 +1,4 @@
-interface AreaDefinition {
+export interface AreaDefinition {
   title: string;
   labels?: readonly string[];
   /**

--- a/src/pages/release-notes/components/grouped-pr-list.tsx
+++ b/src/pages/release-notes/components/grouped-pr-list.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const GroupedPrList: FC<Props> = memo(({ groupedPrs, groups, keyPrefix }) => {
   const sortedGroups = useMemo(
-    () => [...groups].sort((a, b) => a.title.localeCompare(b.title)),
+    () => (groups ? [...groups].sort((a, b) => a.title.localeCompare(b.title)) : [{ title: '' }]),
     [groups]
   );
   return (


### PR DESCRIPTION
This is a temporary hacky workaround for #30. I wanted to get something out quickly for upcoming release, and ideally this is reverted in the future. A real fix will be more involved code wise or will require process improvements with labeling in the Endpoint repo.

Before:
![image](https://github.com/user-attachments/assets/b60e759a-61ab-46f4-b2ea-f42f66a40c1b)

After:
![image](https://github.com/user-attachments/assets/9adf8d15-6d98-48f7-8ba7-0f1040d33598)
