### PR TITLE
Add Serverless release notes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,20 +1,52 @@
 const webpack = require('webpack');
 
-module.exports = (webpackConfig) => {
+module.exports = {
+  webpack: (webpackConfig) => {
     webpackConfig.resolve.fallback = {
-        ...webpackConfig.resolve.fallback,
-        "url": require.resolve("url/"),
-        "querystring": require.resolve("querystring-es3")
+      ...webpackConfig.resolve.fallback,
+      url: require.resolve('url/'),
+      querystring: require.resolve('querystring-es3'),
     };
 
     const basename = process.env.BASENAME;
     if (basename) {
-        webpackConfig.output.publicPath = `/${basename}/`;
+      webpackConfig.output.publicPath = `/${basename}/`;
 
-        webpackConfig.plugins.push(new webpack.DefinePlugin({
-            _BASENAME_: `'${basename}'`
-        }));
+      webpackConfig.plugins.push(
+        new webpack.DefinePlugin({
+          _BASENAME_: `'${basename}'`,
+        })
+      );
     }
 
     return webpackConfig;
-}
+  },
+  devServer: (configFunction) => {
+    return function (proxy, allowedHost) {
+      // Create the default config by calling configFunction with the proxy/allowedHost parameters
+      const config = configFunction(proxy, allowedHost);
+
+      config.client = {
+        ...config.client,
+        overlay: {
+          ...config.client.overlay,
+          runtimeErrors: (error) => {
+            /**
+             * This error occurs every time a version is selected in the wizard,
+             * and causes the overlay to appear. It is stemming from a package.
+             */
+            if (
+              error?.message === 'ResizeObserver loop completed with undelivered notifications.'
+            ) {
+              console.error(error);
+              return false;
+            }
+            return true;
+          },
+        },
+      };
+
+      return config;
+    };
+  },
+};

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   devServer: (configFunction) => {
     return function (proxy, allowedHost) {
-      // Create the default config by calling configFunction with the proxy/allowedHost parameters
+      // Create the default config
       const config = configFunction(proxy, allowedHost);
 
       config.client = {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^41.2.1",
     "@monaco-editor/react": "^4.3.1",
+    "@octokit/graphql-schema": "13.7.0",
     "@octokit/rest": "^18.12.0",
     "@octokit/types": "^6.34.0",
     "@testing-library/jest-dom": "^5.15.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^17.0.11",
     "@xstate/react": "^1.6.3",
     "asciidoctor": "^2.2.5",
+    "lodash.chunk": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.uniq": "^4.5.0",
     "moment": "^2.29.1",
@@ -57,6 +58,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@types/lodash.chunk": "^4.2.9",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.uniq": "^4.5.6",
     "@types/mustache": "^4.1.2",

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -300,6 +300,7 @@ class GitHubService {
       .slice(0, 2)
       .map((item) => item.commit.message.split('See elastic/kibana@')[1]);
 
+    // Need to retrieve all the tags because ref tags are always last
     const tags = await this.octokit
       .paginate(this.octokit.repos.listTags, {
         owner: GITHUB_OWNER,

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -365,12 +365,11 @@ class GitHubService {
     return pullRequests.map((pr) => {
       return {
         ...pr,
-        // @ts-expect-error sadasd
-        labels: pr.labels.nodes,
+        labels: pr.labels?.nodes ?? [],
         user: pr.author,
         html_url: pr.url,
       };
-    });
+    }) as any as PrItem[];
   }
 }
 

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -270,6 +270,22 @@ class GitHubService {
 
     return progressSubject$.asObservable();
   }
+
+  public async getServerlessReleaseSHAs() {
+    /**
+     * Find the last two Kibana commits which were promoted to production-canary successfully. We
+     * cannot use the deploy@ tags from the Kibana repo, since they do not always reach prod. We
+     * need to be careful matching with this query because kibana-controller is managed in serverless-gitops as well.
+     */
+    const commits = await this.octokit.search.commits({
+      q: `repo:${GITHUB_OWNER}/serverless-gitops "gitops: production-canary-ds" "Artifact promotion for kibana to git-"`,
+      sort: 'committer-date',
+    });
+
+    const shas = commits.data.items
+      .slice(0, 2)
+      .map((item) => item.commit.message.split('See elastic/kibana@')[1]);
+  }
 }
 
 let service: GitHubService | undefined;

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -52,7 +52,7 @@ class GitHubService {
   private repoId: number | undefined;
   public repoName: string;
   public serverlessReleaseDate: string | undefined;
-  public serverlessReleaseTag: string | undefined;
+  public serverlessReleaseTag: string = '';
 
   constructor(config: GitHubServiceConfig) {
     this.octokit = config.octokit;

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -275,7 +275,7 @@ class GitHubService {
     return progressSubject$.asObservable();
   }
 
-  public async getServerlessReleaseSHAs() {
+  public async getPrsForServerless() {
     /**
      * Find the last two Kibana commits which were promoted to production-canary successfully. We
      * cannot use the deploy@ tags from the Kibana repo, since they do not always reach prod. We
@@ -342,8 +342,6 @@ class GitHubService {
         }
       });
     });
-
-    console.log(pullRequests);
   }
 }
 

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -51,6 +51,7 @@ class GitHubService {
   private octokit: Octokit;
   private repoId: number | undefined;
   public repoName: string;
+  public serverlessReleaseDate: string | undefined;
 
   constructor(config: GitHubServiceConfig) {
     this.octokit = config.octokit;
@@ -293,6 +294,16 @@ class GitHubService {
       .catch((error) => {
         throw error;
       });
+
+    const commitDate = commits.data.items[0]?.commit?.committer?.date;
+
+    if (commitDate) {
+      this.serverlessReleaseDate = new Date(commitDate).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+    }
 
     const shas = commits.data.items
       .slice(0, 2)

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -287,11 +287,11 @@ class GitHubService {
       .slice(0, 2)
       .map((item) => item.commit.message.split('See elastic/kibana@')[1]);
 
-    const compareResult = await this.octokit.repos.compareCommits({
+    // TODO add error handling
+    const compareResult = await this.octokit.repos.compareCommitsWithBasehead({
       owner: GITHUB_OWNER,
       repo: this.repoName,
-      base: shas[1],
-      head: shas[0],
+      basehead: `${shas[1]}...${shas[0]}`,
     });
     const commitNodeIds = compareResult.data.commits.map((commit) => commit.node_id);
 

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -303,7 +303,7 @@ class GitHubService {
     const tags = await this.octokit
       .paginate(this.octokit.repos.listTags, {
         owner: GITHUB_OWNER,
-        repo: this.repoName,
+        repo: 'kibana',
         per_page: 100,
       })
       .catch((error) => {

--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -19,7 +19,10 @@ type Progress<T> =
 
 export type PrItem = Endpoints['GET /search/issues']['response']['data']['items'][number];
 export type Label = PrItem['labels'][number];
-export type ServerlessPrItem = Pick<PullRequest, 'url' | 'title' | 'number' | 'body' | 'labels'>;
+export type ServerlessPrItem = Pick<
+  PullRequest,
+  'id' | 'url' | 'title' | 'number' | 'body' | 'labels' | 'author'
+>;
 
 interface GitHubServiceConfig {
   octokit: Octokit;
@@ -305,10 +308,14 @@ class GitHubService {
         ... on Commit {
           associatedPullRequests(first: 10) {
             nodes {
+              id
               url
               title
               number
               body
+              author {
+                login
+              }
               labels(first: 50) {
                 nodes {
                   name
@@ -353,6 +360,16 @@ class GitHubService {
           });
         }
       });
+    });
+
+    return pullRequests.map((pr) => {
+      return {
+        ...pr,
+        // @ts-expect-error sadasd
+        labels: pr.labels.nodes,
+        user: pr.author,
+        html_url: pr.url,
+      };
     });
   }
 }

--- a/src/config/templates/index.ts
+++ b/src/config/templates/index.ts
@@ -1,12 +1,13 @@
 import { kibanaTemplate } from './kibana';
 import { securityTemplate } from './security';
 import { endpointTemplate } from './endpoint';
+import { serverlessTemplate } from './serverless';
 import { Config } from './types';
 import type { EuiIconProps } from '@elastic/eui';
 
 export * from './types';
 
-export type TemplateId = 'kibana' | 'security' | 'endpoint';
+export type TemplateId = 'kibana' | 'security' | 'endpoint' | 'serverless';
 
 export interface TemplateInfo {
   id: TemplateId;
@@ -19,4 +20,5 @@ export const templates: TemplateInfo[] = [
   { id: 'kibana', name: 'Kibana', icon: 'logoKibana', config: kibanaTemplate },
   { id: 'security', name: 'Security', icon: 'logoSecurity', config: securityTemplate },
   { id: 'endpoint', name: 'Endpoint', icon: 'logoElastic', config: endpointTemplate },
+  { id: 'serverless', name: 'Serverless', icon: 'logoKibana', config: serverlessTemplate },
 ];

--- a/src/config/templates/serverless.ts
+++ b/src/config/templates/serverless.ts
@@ -21,7 +21,7 @@ export const serverlessTemplate: Config = {
     pages: {
       releaseNotes: `[discrete]
 [[release-notes-{{version}}]]
-=== {{version}}
+=== {{serverlessReleaseDate}}
 {{#prs.breaking}}
 
 [discrete]

--- a/src/config/templates/serverless.ts
+++ b/src/config/templates/serverless.ts
@@ -1,0 +1,72 @@
+import type { Config } from './types';
+
+export const serverlessLabels = [
+  'Team:SecuritySolution',
+  'Team: SecuritySolution',
+  'serverless-bugfix',
+  'serverless-enhancement',
+];
+
+export const serverlessTemplate: Config = {
+  repoName: 'kibana',
+  includedLabels: serverlessLabels,
+  excludedLabels: ['backport', 'release_note:skip', 'reverted'],
+  areas: [
+    {
+      title: 'Elastic Security',
+      labels: serverlessLabels,
+    },
+  ],
+  templates: {
+    pages: {
+      releaseNotes: `[discrete]
+[[release-notes-{{version}}]]
+=== {{version}}
+{{#prs.breaking}}
+
+[discrete]
+[[breaking-changes-{{version}}]]
+==== Breaking changes
+{{{prs.breaking}}}
+{{/prs.breaking}}
+{{#prs.deprecations}}
+
+[discrete]
+[[deprecations-{{version}}]]
+==== Deprecations
+{{{prs.deprecations}}}
+{{/prs.deprecations}}
+{{#prs.features}}
+
+[discrete]
+[[features-{{version}}]]
+==== New features
+{{{prs.features}}}
+{{/prs.features}}
+{{#prs.enhancements}}
+
+[discrete]
+[[enhancements-{{version}}]]
+==== Enhancements
+{{{prs.enhancements}}}
+{{/prs.enhancements}}
+{{#prs.fixes}}
+
+[discrete]
+[[bug-fixes-{{version}}]]
+==== Bug fixes
+{{{prs.fixes}}}
+{{/prs.fixes}}
+
+`,
+    },
+    prGroup: '{{{prs}}}',
+    prs: {
+      breaking: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      deprecation: `*{{{title}}}*\n\n!!TODO!!\n\nSee ({kibana-pull}{{number}}[#{{number}}]) for details.\n`,
+      _other_:
+        '* {{{title}}} ({kibana-pull}{{number}}[#{{number}}]).' +
+        '{{#details}}\n////\n!!TODO!! The above PR had a lengthy release note description:\n{{{details}}}\n////{{/details}}',
+    },
+  },
+};

--- a/src/pages/release-notes/release-note-output.tsx
+++ b/src/pages/release-notes/release-note-output.tsx
@@ -18,8 +18,8 @@ interface Props {
 export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
   const [github] = useGitHubService();
   const config = useActiveConfig();
-  const version = ver.replace(/^v(.*)$/, '$1');
   const isServerless = ver === 'serverless';
+  const version = isServerless ? github.serverlessReleaseTag : ver.replace(/^v(.*)$/, '$1');
   const isPatchVersion = isServerless ? false : semver.patch(version) !== 0;
 
   const renderedGroups = useMemo(() => {

--- a/src/pages/release-notes/release-note-output.tsx
+++ b/src/pages/release-notes/release-note-output.tsx
@@ -1,6 +1,6 @@
 import { EuiFlexGroup, EuiFlexItem, EuiCallOut, EuiCode } from '@elastic/eui';
 import { FC, useMemo } from 'react';
-import { groupByArea, groupPrs, PrItem } from '../../common';
+import { groupByArea, groupPrs, PrItem, useGitHubService } from '../../common';
 import semver from 'semver';
 import {
   renderGroupedByArea,
@@ -16,6 +16,7 @@ interface Props {
 }
 
 export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
+  const [github] = useGitHubService();
   const config = useActiveConfig();
   const version = ver.replace(/^v(.*)$/, '$1');
   const isServerless = ver === 'serverless';
@@ -57,11 +58,13 @@ export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
           prs: renderedGroups,
           nextMajorVersion: isServerless ? '' : `${semver.major(version) + 1}.0.0`,
           isPatchRelease: isPatchVersion,
+          serverlessReleaseDate: github.serverlessReleaseDate,
         }
       ).trim(),
     [
       config.templates.pages.patchReleaseNotes,
       config.templates.pages.releaseNotes,
+      github.serverlessReleaseDate,
       isPatchVersion,
       isServerless,
       renderedGroups,

--- a/src/pages/release-notes/release-note-output.tsx
+++ b/src/pages/release-notes/release-note-output.tsx
@@ -18,7 +18,8 @@ interface Props {
 export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
   const config = useActiveConfig();
   const version = ver.replace(/^v(.*)$/, '$1');
-  const isPatchVersion = semver.patch(version) !== 0;
+  const isServerless = ver === 'serverless';
+  const isPatchVersion = isServerless ? false : semver.patch(version) !== 0;
 
   const renderedGroups = useMemo(() => {
     const grouped = groupPrs(prs, { includeFeaturesInEnhancements: true });
@@ -54,7 +55,7 @@ export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
           version,
           minorVersion: version.replace(/\.\d+$/, ''),
           prs: renderedGroups,
-          nextMajorVersion: `${semver.major(version) + 1}.0.0`,
+          nextMajorVersion: isServerless ? '' : `${semver.major(version) + 1}.0.0`,
           isPatchRelease: isPatchVersion,
         }
       ).trim(),
@@ -62,6 +63,7 @@ export const ReleaseNoteOutput: FC<Props> = ({ prs, version: ver }) => {
       config.templates.pages.patchReleaseNotes,
       config.templates.pages.releaseNotes,
       isPatchVersion,
+      isServerless,
       renderedGroups,
       version,
     ]

--- a/src/pages/release-notes/release-notes.tsx
+++ b/src/pages/release-notes/release-notes.tsx
@@ -38,6 +38,14 @@ export const ReleaseNotes: FC<Props> = ({ version, onVersionChange, ignoredPrior
   const loadPrs = useCallback(async () => {
     setLoading(true);
     setProgress(undefined);
+
+    if (version === 'serverless') {
+      setPrs(await github.getPrsForServerless(config));
+      setLoading(false);
+      setProgress(100);
+      return;
+    }
+
     try {
       subscriptionRef.current = (
         await github.getPrsForVersion(

--- a/src/pages/release-notes/wizard.tsx
+++ b/src/pages/release-notes/wizard.tsx
@@ -46,6 +46,10 @@ export const ReleaseNotesWizard: FC<Props> = ({ onVersionSelected }) => {
     );
   }, [errorHandler, github]);
 
+  useEffect(() => {
+    github.getServerlessReleaseSHAs();
+  }, [github]);
+
   const onValidateVersion = async (version: string): Promise<void> => {
     setValidateVersion(version);
     setIsValidatingVersion(true);

--- a/src/pages/release-notes/wizard.tsx
+++ b/src/pages/release-notes/wizard.tsx
@@ -19,9 +19,9 @@ import {
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState, useCallback } from 'react';
 import { useGitHubService } from '../../common';
-import { getTemplateInfos, setActiveTemplate, TemplateId } from '../../config';
+import { getTemplateInfos, setActiveTemplate, TemplateId, getActiveTemplateId } from '../../config';
 import { ConfigFlyout } from './components';
 
 interface Props {
@@ -30,7 +30,6 @@ interface Props {
 
 export const ReleaseNotesWizard: FC<Props> = ({ onVersionSelected }) => {
   const [github, errorHandler] = useGitHubService();
-
   const [labels, setLabels] = useState<string[]>();
   const [manualLabel, setManualLabel] = useState<string>('');
   const [showConfigFlyout, setShowConfigFlyout] = useState<TemplateId>();
@@ -38,6 +37,7 @@ export const ReleaseNotesWizard: FC<Props> = ({ onVersionSelected }) => {
   const [validateVersion, setValidateVersion] = useState<string>();
   const [isValidatingVersion, setIsValidatingVersion] = useState(false);
   const [previousMissingReleases, setPreviousMissingReleases] = useState<Record<string, boolean>>();
+  const isServerless = getActiveTemplateId() === 'serverless';
 
   useEffect(() => {
     github.getUpcomingReleaseVersions().then(
@@ -46,36 +46,42 @@ export const ReleaseNotesWizard: FC<Props> = ({ onVersionSelected }) => {
     );
   }, [errorHandler, github]);
 
-  useEffect(() => {
-    github.getServerlessReleaseSHAs();
-  }, [github]);
-
-  const onValidateVersion = async (version: string): Promise<void> => {
-    setValidateVersion(version);
-    setIsValidatingVersion(true);
-    try {
-      const missingReleases = await github.getUnreleasedPastLabels(version);
-      setIsValidatingVersion(false);
-      if (missingReleases.length === 0) {
-        onVersionSelected(version);
-      } else {
-        setPreviousMissingReleases(
-          Object.fromEntries(missingReleases.map((release) => [release, false]))
-        );
+  const onValidateVersion = useCallback(
+    async (version: string): Promise<void> => {
+      setValidateVersion(version);
+      setIsValidatingVersion(true);
+      try {
+        const missingReleases = await github.getUnreleasedPastLabels(version);
+        setIsValidatingVersion(false);
+        if (missingReleases.length === 0) {
+          onVersionSelected(version);
+        } else {
+          setPreviousMissingReleases(
+            Object.fromEntries(missingReleases.map((release) => [release, false]))
+          );
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (e: any) {
+        errorHandler(e);
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      errorHandler(e);
+    },
+    [errorHandler, github, onVersionSelected]
+  );
+
+  const onSubmitManualLabel = useCallback(
+    (ev: React.FormEvent): void => {
+      ev.preventDefault();
+      onValidateVersion(manualLabel);
+      setManualLabel('');
+    },
+    [manualLabel, onValidateVersion]
+  );
+
+  const onGenerateReleaseNotes = useCallback(() => {
+    if (isServerless) {
+      onVersionSelected('serverless');
     }
-  };
 
-  const onSubmitManualLabel = (ev: React.FormEvent): void => {
-    ev.preventDefault();
-    onValidateVersion(manualLabel);
-    setManualLabel('');
-  };
-
-  const onGenerateReleaseNotes = () => {
     if (validateVersion) {
       onVersionSelected(
         validateVersion,
@@ -84,220 +90,254 @@ export const ReleaseNotesWizard: FC<Props> = ({ onVersionSelected }) => {
           .map(([release]) => release)
       );
     }
-  };
+  }, [isServerless, onVersionSelected, previousMissingReleases, validateVersion]);
 
-  const steps: EuiStepsProps['steps'] = [
-    {
-      title: 'Select release notes to generate',
-      children: (
-        <EuiFormFieldset>
-          {templates.map((template) => (
-            <React.Fragment key={template.id}>
-              <EuiCheckableCard
-                id={template.id}
-                onChange={() => {
-                  setTemplates(setActiveTemplate(template.id));
-                }}
-                checked={template.active}
-                label={
-                  <EuiFlexGroup gutterSize="s" alignItems="center">
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type={template.icon} />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={true}>
-                      <EuiText size="m">{template.name}</EuiText>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
-                        iconType="gear"
-                        size="xs"
-                        onClick={() => setShowConfigFlyout(template.id)}
-                      >
-                        Customize config
-                        {template.modified && <> (modified)</>}
-                      </EuiButtonEmpty>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}></EuiFlexItem>
-                  </EuiFlexGroup>
-                }
-              />
-              <EuiSpacer size="m" />
-            </React.Fragment>
-          ))}
-        </EuiFormFieldset>
-      ),
-    },
-    {
-      title: 'Select a version',
-      status: labels ? 'current' : 'loading',
-      children: !labels ? (
-        'Loading labels …'
-      ) : (
-        <>
-          <EuiFlexGroup wrap={true} justifyContent="flexStart">
-            {labels?.map((label) => (
-              <EuiFlexItem grow={false} key={label}>
-                <EuiButton
-                  disabled={isValidatingVersion}
-                  fill={!validateVersion || validateVersion === label}
-                  onClick={() => onValidateVersion(label)}
-                  iconType={validateVersion === label ? 'check' : undefined}
-                >
-                  {label}
-                </EuiButton>
-              </EuiFlexItem>
+  const getSteps = useMemo(() => {
+    const baseSteps: EuiStepsProps['steps'] = [
+      {
+        title: 'Select release notes to generate',
+        children: (
+          <EuiFormFieldset>
+            {templates.map((template) => (
+              <React.Fragment key={template.id}>
+                <EuiCheckableCard
+                  id={template.id}
+                  onChange={() => {
+                    setTemplates(setActiveTemplate(template.id));
+                  }}
+                  checked={template.active}
+                  label={
+                    <EuiFlexGroup gutterSize="s" alignItems="center">
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type={template.icon} />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={true}>
+                        <EuiText size="m">{template.name}</EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiButtonEmpty
+                          iconType="gear"
+                          size="xs"
+                          onClick={() => setShowConfigFlyout(template.id)}
+                        >
+                          Customize config
+                          {template.modified && <> (modified)</>}
+                        </EuiButtonEmpty>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}></EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                />
+                <EuiSpacer size="m" />
+              </React.Fragment>
             ))}
-            {validateVersion && !labels.includes(validateVersion) && (
-              <EuiFlexItem grow={false}>
-                <EuiButton disabled={isValidatingVersion} fill iconType="check">
-                  {validateVersion}
-                </EuiButton>
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-          <EuiSpacer size="l" />
-          <form onSubmit={onSubmitManualLabel}>
-            <EuiFlexGroup gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiFormRow
-                  label="or enter a version"
-                  error={'Version must be in format vX.Y.Z'}
-                  isInvalid={!!manualLabel && !manualLabel.match(/^v\d+\.\d+\.\d+$/)}
-                >
-                  <EuiFieldText
-                    placeholder="e.g. v7.12.0"
-                    value={manualLabel}
-                    onChange={(ev) => setManualLabel(ev.target.value)}
-                    isInvalid={!!manualLabel && !manualLabel.match(/^v\d+\.\d+\.\d+$/)}
-                  />
-                </EuiFormRow>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiFormRow hasEmptyLabelSpace>
-                  <EuiButton
-                    disabled={!manualLabel || !manualLabel?.match(/^v\d+\.\d+\.\d+$/)}
-                    type="submit"
-                  >
-                    Apply
-                  </EuiButton>
-                </EuiFormRow>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </form>
-        </>
-      ),
-    },
-    {
-      title: previousMissingReleases
-        ? 'Found version labels without release'
-        : 'Validate release version',
-      status: isValidatingVersion ? 'loading' : validateVersion ? 'warning' : 'incomplete',
-      children: (
-        <>
-          {isValidatingVersion && <EuiTextColor>Checking previous releases …</EuiTextColor>}
-          {!isValidatingVersion && !validateVersion && (
-            <EuiTextColor color="subdued">Please select a version above to continue.</EuiTextColor>
-          )}
-          {!isValidatingVersion && validateVersion && (
+          </EuiFormFieldset>
+        ),
+      },
+    ];
+
+    if (isServerless) {
+      return baseSteps.concat([
+        {
+          title: 'Generate notes for the most recent Serverless release',
+          children: (
             <>
-              <EuiCallOut color="warning" size="m">
-                <EuiText size="relative">
-                  The following older version labels exist in the repository, but actually have not
-                  been released (yet). For the release note generation to work, please mark versions
-                  that will still be released. Leave versions unmarked if there is no release
-                  planned for this version.
-                  <EuiSpacer size="s" />
-                  <EuiAccordion id="unreleasedVersionMoreDetails" buttonContent="More details">
-                    <EuiSpacer size="s" />
-                    <p>
-                      <strong>How does this tool determine PRs for a version?</strong> Version
-                      labels on PRs determine in which version's release note a PR appears. The way
-                      version labels are used in the repository, can cause a PR to have multiple
-                      version labels attached. That PR should nevertheless only show up in the
-                      earliest version it got released, e.g. a PR with the labels v7.10.2, v7.11.0
-                      and v8.0.0 should only appear in the v7.10.2 release notes. This tool makes
-                      sure it will only be included in the release note of the earliest version.
-                    </p>
-                    <p>
-                      <strong>What is the problem with unreleased version labels?</strong> PRs with
-                      a version label assigned for a version that never will be released are causing
-                      problems. Scenario: a PR has the labels v7.10.3, v7.11.1, v7.12.0, v8.0.0 with
-                      7.10.3 never being an actual release. This tool would now assume that this PR
-                      should show up in v7.10.3's release notes, which never existed, and thus the
-                      PR will never be listed in any release notes.
-                    </p>
-                    <p>
-                      <strong>Why do those unreleased labels exist?</strong> Sometimes the release
-                      was originally planned and then canceled, sometimes some engineer created that
-                      label while that release was never planned and then the label ended up on more
-                      and more PRs.
-                    </p>
-                    <p>
-                      <strong>What do I need to do here?</strong> This tool retrieves a list of
-                      existing version labels from the two minor versions prior to the selected
-                      version. It will check if any of them does not match an existing release. For
-                      each of those version labels without a matching release you'll need to specify
-                      how it should be treated:
-                    </p>
-                    <div>
-                      <EuiSwitch
-                        checked={true}
-                        onChange={() => null}
-                        compressed
-                        label=""
-                        style={{ cursor: 'default' }}
-                      />{' '}
-                      The version will still be released, it just hasn't happened <em>yet</em>. No
-                      special behavior will be applied.
-                    </div>
-                    <EuiSpacer size="s" />
-                    <div>
-                      <EuiSwitch
-                        checked={false}
-                        onChange={() => null}
-                        compressed
-                        label=""
-                        style={{ cursor: 'default' }}
-                      />{' '}
-                      The version will never be released. The tool will ignore this label and treat
-                      PRs, like they wouldn't have this label attached, i.e. they move into the
-                      release notes for the next highest version label attached.
-                    </div>
-                  </EuiAccordion>
-                </EuiText>
-              </EuiCallOut>
-              <EuiSpacer />
-              <EuiTitle size="xs">
-                <h3>Which versions will still be released?</h3>
-              </EuiTitle>
-              <EuiSpacer size="m" />
-              {previousMissingReleases &&
-                Object.entries(previousMissingReleases).map(([release, checked]) => (
-                  <EuiFormRow key={release}>
-                    <EuiSwitch
-                      label={release}
-                      checked={checked}
-                      onChange={() =>
-                        setPreviousMissingReleases((prev) => ({ ...prev, [release]: !checked }))
-                      }
-                      compressed
-                    />
-                  </EuiFormRow>
-                ))}
-              <EuiSpacer />
               <EuiButton fill onClick={onGenerateReleaseNotes}>
                 Generate release notes
               </EuiButton>
             </>
-          )}
-        </>
-      ),
-    },
-  ];
+          ),
+        },
+      ]);
+    }
+
+    return baseSteps.concat([
+      {
+        title: 'Select a version',
+        status: labels ? 'current' : 'loading',
+        children: !labels ? (
+          'Loading labels …'
+        ) : (
+          <>
+            <EuiFlexGroup wrap={true} justifyContent="flexStart">
+              {labels?.map((label) => (
+                <EuiFlexItem grow={false} key={label}>
+                  <EuiButton
+                    disabled={isValidatingVersion}
+                    fill={!validateVersion || validateVersion === label}
+                    onClick={() => onValidateVersion(label)}
+                    iconType={validateVersion === label ? 'check' : undefined}
+                  >
+                    {label}
+                  </EuiButton>
+                </EuiFlexItem>
+              ))}
+              {validateVersion && !labels.includes(validateVersion) && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton disabled={isValidatingVersion} fill iconType="check">
+                    {validateVersion}
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+            <EuiSpacer size="l" />
+            <form onSubmit={onSubmitManualLabel}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiFormRow
+                    label="or enter a version"
+                    error={'Version must be in format vX.Y.Z'}
+                    isInvalid={!!manualLabel && !manualLabel.match(/^v\d+\.\d+\.\d+$/)}
+                  >
+                    <EuiFieldText
+                      placeholder="e.g. v7.12.0"
+                      value={manualLabel}
+                      onChange={(ev) => setManualLabel(ev.target.value)}
+                      isInvalid={!!manualLabel && !manualLabel.match(/^v\d+\.\d+\.\d+$/)}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiFormRow hasEmptyLabelSpace>
+                    <EuiButton
+                      disabled={!manualLabel || !manualLabel?.match(/^v\d+\.\d+\.\d+$/)}
+                      type="submit"
+                    >
+                      Apply
+                    </EuiButton>
+                  </EuiFormRow>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </form>
+          </>
+        ),
+      },
+      {
+        title: previousMissingReleases
+          ? 'Found version labels without release'
+          : 'Validate release version',
+        status: isValidatingVersion ? 'loading' : validateVersion ? 'warning' : 'incomplete',
+        children: (
+          <>
+            {isValidatingVersion && <EuiTextColor>Checking previous releases …</EuiTextColor>}
+            {!isValidatingVersion && !validateVersion && (
+              <EuiTextColor color="subdued">
+                Please select a version above to continue.
+              </EuiTextColor>
+            )}
+            {!isValidatingVersion && validateVersion && (
+              <>
+                <EuiCallOut color="warning" size="m">
+                  <EuiText size="relative">
+                    The following older version labels exist in the repository, but actually have
+                    not been released (yet). For the release note generation to work, please mark
+                    versions that will still be released. Leave versions unmarked if there is no
+                    release planned for this version.
+                    <EuiSpacer size="s" />
+                    <EuiAccordion id="unreleasedVersionMoreDetails" buttonContent="More details">
+                      <EuiSpacer size="s" />
+                      <p>
+                        <strong>How does this tool determine PRs for a version?</strong> Version
+                        labels on PRs determine in which version's release note a PR appears. The
+                        way version labels are used in the repository, can cause a PR to have
+                        multiple version labels attached. That PR should nevertheless only show up
+                        in the earliest version it got released, e.g. a PR with the labels v7.10.2,
+                        v7.11.0 and v8.0.0 should only appear in the v7.10.2 release notes. This
+                        tool makes sure it will only be included in the release note of the earliest
+                        version.
+                      </p>
+                      <p>
+                        <strong>What is the problem with unreleased version labels?</strong> PRs
+                        with a version label assigned for a version that never will be released are
+                        causing problems. Scenario: a PR has the labels v7.10.3, v7.11.1, v7.12.0,
+                        v8.0.0 with 7.10.3 never being an actual release. This tool would now assume
+                        that this PR should show up in v7.10.3's release notes, which never existed,
+                        and thus the PR will never be listed in any release notes.
+                      </p>
+                      <p>
+                        <strong>Why do those unreleased labels exist?</strong> Sometimes the release
+                        was originally planned and then canceled, sometimes some engineer created
+                        that label while that release was never planned and then the label ended up
+                        on more and more PRs.
+                      </p>
+                      <p>
+                        <strong>What do I need to do here?</strong> This tool retrieves a list of
+                        existing version labels from the two minor versions prior to the selected
+                        version. It will check if any of them does not match an existing release.
+                        For each of those version labels without a matching release you'll need to
+                        specify how it should be treated:
+                      </p>
+                      <div>
+                        <EuiSwitch
+                          checked={true}
+                          onChange={() => null}
+                          compressed
+                          label=""
+                          style={{ cursor: 'default' }}
+                        />{' '}
+                        The version will still be released, it just hasn't happened <em>yet</em>. No
+                        special behavior will be applied.
+                      </div>
+                      <EuiSpacer size="s" />
+                      <div>
+                        <EuiSwitch
+                          checked={false}
+                          onChange={() => null}
+                          compressed
+                          label=""
+                          style={{ cursor: 'default' }}
+                        />{' '}
+                        The version will never be released. The tool will ignore this label and
+                        treat PRs, like they wouldn't have this label attached, i.e. they move into
+                        the release notes for the next highest version label attached.
+                      </div>
+                    </EuiAccordion>
+                  </EuiText>
+                </EuiCallOut>
+                <EuiSpacer />
+                <EuiTitle size="xs">
+                  <h3>Which versions will still be released?</h3>
+                </EuiTitle>
+                <EuiSpacer size="m" />
+                {previousMissingReleases &&
+                  Object.entries(previousMissingReleases).map(([release, checked]) => (
+                    <EuiFormRow key={release}>
+                      <EuiSwitch
+                        label={release}
+                        checked={checked}
+                        onChange={() =>
+                          setPreviousMissingReleases((prev) => ({ ...prev, [release]: !checked }))
+                        }
+                        compressed
+                      />
+                    </EuiFormRow>
+                  ))}
+                <EuiSpacer />
+                <EuiButton fill onClick={onGenerateReleaseNotes}>
+                  Generate release notes
+                </EuiButton>
+              </>
+            )}
+          </>
+        ),
+      },
+    ]);
+  }, [
+    isServerless,
+    isValidatingVersion,
+    labels,
+    manualLabel,
+    onGenerateReleaseNotes,
+    onSubmitManualLabel,
+    onValidateVersion,
+    previousMissingReleases,
+    templates,
+    validateVersion,
+  ]);
 
   return (
     <EuiPageTemplate pageHeader={{ pageTitle: 'Release Notes' }}>
-      <EuiSteps steps={steps} />
+      <EuiSteps steps={getSteps} />
       {showConfigFlyout && (
         <ConfigFlyout
           templateId={showConfigFlyout}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,6 +3068,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.chunk@^4.2.9":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.chunk/-/lodash.chunk-4.2.9.tgz#60da44c404dfa8b01b426034c1183e5eb9b09727"
+  integrity sha512-Z9VtFUSnmT0No/QymqfG9AGbfOA4O5qB/uyP89xeZBqDAsKsB4gQFTqt7d0pHjbsTwtQ4yZObQVHuKlSOhIJ5Q==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.clonedeep@^4.5.6":
   version "4.5.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
@@ -7831,6 +7838,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+  integrity sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,6 +2537,14 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/graphql-schema@13.7.0":
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql-schema/-/graphql-schema-13.7.0.tgz#65e98c691e90311b04c8b5add2ebb7140f79ac8c"
+  integrity sha512-Ij8epnvFh7TfgrFg6j10317oZGAKQ48VBEfz3ebwYFtvkf471tcmULEKny0r1bHKoQ/uYhtR13i9x7O6fwSZFg==
+  dependencies:
+    graphql "^16.0.0"
+    graphql-tag "^2.10.3"
+
 "@octokit/graphql@^4.5.8":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
@@ -6266,6 +6274,18 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+graphql-tag@^2.10.3:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql@^16.0.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.9.0.tgz#1c310e63f16a49ce1fbb230bd0a000e99f6f115f"
+  integrity sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==
 
 gzip-size@^6.0.0:
   version "6.0.0"
@@ -11033,6 +11053,11 @@ tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Closes elastic/kibana#197152

This adds basic support for generating Serverless release notes. Currently it is only scoped to Security project by the labels in the `serverless` template/config. It should easily be extendable for the other project types.

Prepare release notes view:
![image](https://github.com/user-attachments/assets/7e5f2e94-e05b-4ce2-9485-65d95dc478eb)

The generated ascii:
```
[discrete]
[[release-notes-deploy@1731910526]]
=== November 17, 2024

[discrete]
[[bug-fixes-deploy@1731910526]]
==== Bug fixes
* Fixes Asset Criticality index issue when setting up entity engines concurrently ({kibana-pull}199486[#199486]).
* Improve asset criticality bulk error when entities are duplicated ({kibana-pull}199651[#199651]).
* Update file validation because the file type is empty on windows ({kibana-pull}199791[#199791]).
* Fixes `required_fields` being removed after rule `PATCH` calls ({kibana-pull}199901[#199901]).
```



### Future improvements
- #36