### PR TITLE
Remove redundant wording in release notes

### DIFF
--- a/src/config/templates/kibana.ts
+++ b/src/config/templates/kibana.ts
@@ -333,10 +333,12 @@ The {{version}} release includes the following bug fixes.
 [%collapsible]
 ====
 *Details* +
-!!TODO!! For more information, refer to ({kibana-pull}{{number}}[#{{number}}]).
+!!TODO!!
 
 *Impact* +
 !!TODO!!
+
+View ({kibana-pull}{{number}}[#{{number}}])
 ====
       `,
       deprecation: `[discrete]
@@ -345,10 +347,12 @@ The {{version}} release includes the following bug fixes.
 [%collapsible]
 ====
 *Details* +
-!!TODO!! For more information, refer to ({kibana-pull}{{number}}[#{{number}}]).
+!!TODO!!
 
 *Impact* +
 !!TODO!!
+
+View ({kibana-pull}{{number}}[#{{number}}])
 ====
       `,
       _other_:


### PR DESCRIPTION
This PR simplifies the reference to PRs in breaking changes and deprecations as per https://elastic.slack.com/archives/CED7QCL3E/p1741876335384619?thread_ts=1741874943.281489&cid=CED7QCL3E