### PR TITLE
Fix Endpoint preview. Allow wildcard groupings

### DIFF
--- a/src/common/pr-utils/grouping.ts
+++ b/src/common/pr-utils/grouping.ts
@@ -22,7 +22,8 @@ export function groupByArea(prs: PrItem[], { areas }: Config): GroupedByArea {
   const grouped = prs.reduce<{ unknown: PrItem[]; areas: { [title: string]: PrItem[] } }>(
     (grouped, pr) => {
       const matchingAreas = areas.filter(
-        ({ labels }) => labels && pr.labels.some(({ name }) => name && labels.includes(name))
+        ({ labels }) =>
+          labels === '*' || (labels && pr.labels.some(({ name }) => name && labels.includes(name)))
       );
 
       if (matchingAreas.length === 0) {

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -6,7 +6,7 @@ export const endpointTemplate: Config = {
   excludedLabels: ['backport', 'release_note:skip'],
   areas: [
     {
-      title: 'Elastic Endpoint',
+      title: '',
       labels: '*',
     },
   ],

--- a/src/config/templates/endpoint.ts
+++ b/src/config/templates/endpoint.ts
@@ -7,6 +7,7 @@ export const endpointTemplate: Config = {
   areas: [
     {
       title: 'Elastic Endpoint',
+      labels: '*',
     },
   ],
   templates: {

--- a/src/config/templates/types.ts
+++ b/src/config/templates/types.ts
@@ -1,6 +1,6 @@
 export interface AreaDefinition {
   title: string;
-  labels?: readonly string[];
+  labels?: readonly string[] | '*';
   /**
    * If a PR can fall into multiple areas it will fall into the area with the highest priority.
    * If all areas it would be under have the same priority the result is random.


### PR DESCRIPTION
Closes #42
Closes #30 

The Endpoint repo doesn't use grouping my area/team like Kibana. This causes the notes preview to incorrectly list all PRs as "unknown" grouping. This PR allows wildcard grouping to workaround that:

![image](https://github.com/user-attachments/assets/0607efc3-4279-4624-a01b-5cb52482fa33)
