### PR TITLE
Fix undefined SHA in Serverless commit comparison.

### DIFF
--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -298,7 +298,10 @@ class GitHubService {
 
     const shas = commits.data.items
       .slice(0, 2)
-      .map((item) => item.commit.message.split('See elastic/kibana@')[1]);
+      .map(
+        (item) =>
+          item.commit.message.split('Artifact promotion for kibana to git-')[1].split('\n')[0]
+      );
 
     // Need to retrieve all the tags because ref tags are always last
     const tags = await this.octokit


### PR DESCRIPTION
Some Serverless deployment commit messages have the following format (or it's a new format):

`"gitops: production-canary-ds-1,production-canary-ds-2 Artifact promotion for kibana to git-0e551327c8e6\n\nSee https://github.com/elastic/kibana/compare/9e2261df3494ffe83d3b9fd0b13b05b7f2258fa7...0e551327c8e6"`

This results in a `sha` comparison of `[undefined, <sha2>]` and infinite loading spinner.

#### This is just a hacky workaround to get the release notes out this week. Will find a less brittle solution afterwards.