### PR TITLE
Fix missing release date for serverless output

### DIFF
--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -69,7 +69,6 @@ export class GitHubService {
   public repoName: string;
   private serverlessReleases: ServerlessRelease[] = [];
   public serverlessReleaseDate: Date | undefined;
-  public serverlessReleaseTag: string = '';
 
   constructor(config: GitHubServiceConfig) {
     this.octokit = config.octokit;


### PR DESCRIPTION
Removes unused `serverlessReleaseTag` and adds back a chunk of code I forgot during #52:
https://github.com/elastic/kibana-release-notes/pull/52/files#diff-f8b3eab5fd279bcc044c97811813d76b77a811fc92bfd3797d4c2e9a5ba88ed9L321

```md
<!-- Before -->
##  [serverless-changelog-]
### Features and enhancements [serverless-changelog--features-enhancements]
### Fixes [serverless-changelog--fixes]

<!-- After -->
## October 13, 2025 [serverless-changelog-10132025]
### Features and enhancements [serverless-changelog-10132025-features-enhancements]
### Fixes [serverless-changelog-10132025-fixes]
```