### PR TITLE
Switch back to canary prod for Serverless notes

### DIFF
--- a/src/common/github-service.ts
+++ b/src/common/github-service.ts
@@ -305,7 +305,7 @@ export class GitHubService {
    * Find commits which updated the production environment and extract the deployed Kibana SHAs
    */
   public async getServerlessReleases(): Promise<ServerlessRelease[]> {
-    const envSearch = 'production-noncanary-ds-1';
+    const envSearch = 'production-canary-ds-1';
     const serverlessGitOpsRepo = 'serverless-gitops';
     const versionsFilePath = 'services/kibana/versions.yaml';
     this.setLoading?.(true);


### PR DESCRIPTION
In #52 we switch to `prod-noncanary` channel instead of `canary` incase a release didn't complete. This means the docs team has to wait for the full deployment to finish before any work on release notes can be started. Their preference is to generate notes using `canary` deployments so that they can have the notes ready for `noncanary` release to customers.