### PR TITLE
Add test steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tool to generate the Kibana release notes. Deployed at [release-notes.kibanateam
 
 ## Steps to test locally
 
-1. Install dependencies (if not already installed):
+1. Install dependencies:
 
 ```sh
 yarn install

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ yarn install
 yarn start
 ```
 
+3. Run tests:
+
+```sh
+yarn test
+```
+
 The app runs on port 4000 (configured in `package.json`).
 After starting, it should open at http://localhost:4000.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Kibana Release Notes
 
 Tool to generate the Kibana release notes. Deployed at [release-notes.kibanateam.dev](https://release-notes.kibanateam.dev)
+
+## Steps to test locally
+
+1. Install dependencies (if not already installed):
+
+```sh
+yarn install
+```
+
+2. Start the tool:
+
+```sh
+yarn start
+```
+
+The app runs on port 4000 (configured in `package.json`).
+After starting, it should open at http://localhost:4000.
+
+NOTE: In order for the tool to generate release notes, you must provide a [Github token](https://github.com/settings/tokens) with the `public_repo` permission for public repos or the full `repo` scope for private repos.


### PR DESCRIPTION
I think it doesn't hurt to put this info about how to test locally (and the required github token) directly in the readme.

AI-Assisted: This PR was assisted by Cursor. 
Usage: Used to find the testing steps and draft the initial readme update.