### PR TITLE
Adds the new `Team:actionable-obs` label to the common file

### DIFF
--- a/src/config/templates/common.ts
+++ b/src/config/templates/common.ts
@@ -146,6 +146,7 @@ export const observabilityLabels = [
   'Feature:Logs UI',
   'Feature:Infra UI',
   'Feature:Service Maps',
+  'Team:actionable-obs',
 ];
 
 export const kibanaAreas: AreaDefinition[] = [


### PR DESCRIPTION
Adds the new `Team:actionable-obs` label to the common file (common.ts) to ensure PRs with that label are retrieved when we run the release notes tool to complile Observability and Kibana release notes for ESS. This PR should also ensure that the tool retrieves PRs with the `Team:actionable-obs` label when Serverless release notes are generated. 