### PR TITLE
Update logic to ignore comments from PR templates

### DIFF
--- a/src/common/pr-utils/extracting.test.ts
+++ b/src/common/pr-utils/extracting.test.ts
@@ -127,6 +127,51 @@ Next paragraph
         'This is the extracted sentence.'
       );
     });
+
+    it('should ignore HTML comments and extract the actual release note', () => {
+      expect(
+        findReleaseNote(`
+## Release Note
+<!-- 
+Use mandatory template {elastic-defend} which will be substituted with proper brand name, i.e Elastic Defend
+-->
+This is the actual release note.
+
+## Checklist
+      `)
+      ).toBe('This is the actual release note.');
+    });
+
+    it('should extract release note even when comment creates extra blank lines', () => {
+      // This simulates the endpoint-dev PR template where the comment
+      // is on its own lines, creating blank lines when stripped
+      expect(
+        findReleaseNote(`
+## Release Note
+<!-- 
+Use mandatory template {elastic-defend} which will be substituted with proper brand name, i.e Elastic Defend
+-->
+{elastic-defend} Fixed Mark of the Web parsing on Windows so file origin information is parsed correctly.
+
+## Checklist
+      `)
+      ).toBe(
+        '{elastic-defend} Fixed Mark of the Web parsing on Windows so file origin information is parsed correctly.'
+      );
+    });
+
+    it('should strip multiple HTML comments', () => {
+      expect(
+        findReleaseNote(`
+## Release Note
+<!-- comment 1 -->
+Actual note here
+<!-- comment 2 -->
+
+## Next section
+      `)
+      ).toBe('Actual note here');
+    });
   });
 
   describe('extractReleaseNotes', () => {

--- a/src/common/pr-utils/extracting.ts
+++ b/src/common/pr-utils/extracting.ts
@@ -75,14 +75,42 @@ export function normalizeTitle(
 }
 
 /**
+ * Strips HTML comments from markdown text.
+ * This handles both single-line and multi-line comments.
+ * Also collapses excessive blank lines that may result from comment removal,
+ * to prevent creating artificial section breaks.
+ */
+function stripHtmlComments(markdown: string): string {
+  return (
+    markdown
+      // Remove HTML comments
+      .replace(/<!--[\s\S]*?-->/g, '')
+      // Collapse 3+ consecutive newlines into 2 (preserving paragraph breaks but not creating extra ones)
+      .replace(/(\r?\n){3,}/g, '\n\n')
+  );
+}
+
+/**
  * Finds and retrieves the actual "release note" details from a PR description (in markdown format).
  * It will look for:
  * - paragraphs beginning with release note (or slight variations of that) and the sentence till the end of line.
+ *
+ * HTML comments are stripped before extraction to avoid picking up template instructions.
  */
 export function findReleaseNote(markdown: string): string | undefined {
-  const match = markdown.match(
-    /(?:\n|^)\s*#*\s*release[\s-]?notes?[\s\W]+(.*?)(?:(\r?\n|\r){2}|$|((\r?\n|\r)\s*#+))/is
+  // Strip HTML comments first to avoid extracting template instructions
+  const cleanedMarkdown = stripHtmlComments(markdown);
+
+  // Regex breakdown:
+  // - (?:\n|^)\s*#*\s* - start of line, optional whitespace and markdown headers
+  // - release[\s-]?notes? - matches "release note", "release notes", "release-note", etc.
+  // - [:\s-]* - matches separator after "release note" (colon, dash, whitespace) but NOT other non-word chars like {
+  // - (.*?) - lazily capture the release note content
+  // - Terminator: double newline, end of string, or new markdown header
+  const match = cleanedMarkdown.match(
+    /(?:\n|^)\s*#*\s*release[\s-]?notes?[:\s-]*(.*?)(?:(\r?\n|\r){2}|$|((\r?\n|\r)\s*#+))/is
   );
+
   return match?.[1].trim() ?? undefined;
 }
 


### PR DESCRIPTION
This PR fixes an issue happening mainly with the Endpoint-dev repository.

The issue was that in this repo a PR template was recently introduced that contain comments
<img width="1532" height="318" alt="image" src="https://github.com/user-attachments/assets/808e8092-5375-4811-adff-886feaaf3ec6" />

This prevented the RN tool from running properly: PRs were still listed, but with the code comment as content (both in the preview and the generated content) instead of any other content manually added to that section by PR authors, which was just not rendered at all and totally ignored. Resulting in things like this:

<img width="720" height="694" alt="image" src="https://github.com/user-attachments/assets/fa9fb04c-9c3b-437d-b0fd-72d934a1fa04" />


With these changes, the same would now be correctly showing:

<img width="895" height="890" alt="image" src="https://github.com/user-attachments/assets/86b18648-b6bb-4c58-949a-0adb9d81ea51" />


Coded with Claude Sonnet 4.5
Tested manually locally (for endpoint and for any undesired side effects in other release notes