### PR TITLE
Add Security team and feature labels

### DIFF
--- a/src/config/templates/common.ts
+++ b/src/config/templates/common.ts
@@ -119,6 +119,8 @@ export const securityLabels = [
   'Team:Defend Workflows',
   'Team:Detection Rules',
   'Team:Security-Scalability',
+  'Team:Automatic Migrations',
+  'Feature:SIEMMigrations',
   'Feature:Timeline',
   'Feature:Detection Rules',
   'Feature:Detection Alerts',


### PR DESCRIPTION
Add the Security-related labels `Team:Automatic Migrations` and  `Feature:SIEMMigrations` to the Security labels config to ensure these PRs are being correctly picked up.