### PR TITLE
add Cursor worktree setup

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "yarn install --frozen-lockfile"
+  ]
+}


### PR DESCRIPTION
## Summary
- add repo-local Cursor worktree setup for isolated worktrees

## Test plan
- [x] verify `.cursor/worktrees.json` contains the repo bootstrap command

Made with [Cursor](https://cursor.com)