### PR TITLE
Improve Kibana release note label routing

### DIFF
--- a/src/config/templates/common.test.ts
+++ b/src/config/templates/common.test.ts
@@ -1,0 +1,51 @@
+import type { PrItem } from '../../common/github-service';
+import { groupByArea } from '../../common/pr-utils/grouping';
+import { observabilityLabels, securityLabels } from './common';
+import { kibanaTemplate } from './kibana';
+
+const createPr = (labels: string[]): PrItem =>
+  ({
+    labels: labels.map((name) => ({ name })),
+  } as PrItem);
+
+const getAreaTitle = (labels: string[]): string => {
+  const [groupedAreas] = groupByArea([createPr(labels)], kibanaTemplate);
+
+  return Object.keys(groupedAreas)[0];
+};
+
+describe('Kibana release note areas', () => {
+  it('recognizes current Security solution labels', () => {
+    expect(securityLabels).toEqual(
+      expect.arrayContaining([
+        'Team:Detection Engineering',
+        'Team:Security Deployment',
+        'Team:Automatic Migrations',
+        'Feature:Security ML Jobs',
+      ])
+    );
+  });
+
+  it('recognizes current Observability solution labels', () => {
+    expect(observabilityLabels).toEqual(
+      expect.arrayContaining(['Team:streams-ui', 'Feature:SigEvents', 'Team:obs-ai - DEPRECATED'])
+    );
+    expect(observabilityLabels).not.toContain('ci:project-deploy-observability');
+  });
+
+  it.each([
+    [['feature:agent-builder', 'Team:AI Infra'], 'Agent Builder'],
+    [['Feature:Inference UI', 'Team:Search'], 'Machine learning and inference'],
+    [['Feature:ES|QL', 'Team:DataDiscovery'], 'ES|QL'],
+    [['Team:One Workflow'], 'Workflows'],
+  ])('routes %j to %s', (labels, expectedArea) => {
+    expect(getAreaTitle(labels)).toBe(expectedArea);
+  });
+
+  it.each([
+    [['Feature:Security ML Jobs', 'Feature:ML/AIOps'], 'Elastic Security solution'],
+    [['Feature:SigEvents', 'Team:Presentation'], 'Elastic Observability solution'],
+  ])('prioritizes solution routing for %j', (labels, expectedArea) => {
+    expect(getAreaTitle(labels)).toBe(expectedArea);
+  });
+});

--- a/src/config/templates/common.test.ts
+++ b/src/config/templates/common.test.ts
@@ -22,6 +22,7 @@ describe('Kibana release note areas', () => {
         'Team:Security Deployment',
         'Team:Automatic Migrations',
         'Feature:Security ML Jobs',
+        'Feature:Endpoint',
       ])
     );
   });
@@ -44,6 +45,7 @@ describe('Kibana release note areas', () => {
 
   it.each([
     [['Feature:Security ML Jobs', 'Feature:ML/AIOps'], 'Elastic Security solution'],
+    [['Feature:Endpoint', 'Team:Fleet'], 'Elastic Security solution'],
     [['Feature:SigEvents', 'Team:Presentation'], 'Elastic Observability solution'],
   ])('prioritizes solution routing for %j', (labels, expectedArea) => {
     expect(getAreaTitle(labels)).toBe(expectedArea);

--- a/src/config/templates/common.ts
+++ b/src/config/templates/common.ts
@@ -120,6 +120,9 @@ export const securityLabels = [
   'Team:Detection Rules',
   'Team:Security-Scalability',
   'Team:Detection Rule Management',
+  'Team:Detection Engineering',
+  'Team:Security Deployment',
+  'Team:Automatic Migrations',
   'Feature:SIEMMigrations',
   'Feature:Timeline',
   'Feature:Detection Rules',
@@ -128,6 +131,7 @@ export const securityLabels = [
   'Feature:Rule Exceptions',
   'Feature:AutomaticImport',
   'Feature:Event Correlation (EQL) Rule',
+  'Feature:Security ML Jobs',
 ];
 
 export const observabilityLabels = [
@@ -140,7 +144,6 @@ export const observabilityLabels = [
   'Team:obs-onboarding',
   'Team:obs-knowledge',
   'Team:obs-entities',
-  'ci:project-deploy-observability',
   'Feature:Uptime',
   'Team:uptime',
   'Team:apm',
@@ -157,6 +160,9 @@ export const observabilityLabels = [
   'Team:Observability',
   'author:actionable-obs',
   'Feature:Streams',
+  'Team:streams-ui',
+  'Feature:SigEvents',
+  'Team:obs-ai - DEPRECATED',
 ];
 
 export const kibanaAreas: AreaDefinition[] = [
@@ -165,9 +171,15 @@ export const kibanaAreas: AreaDefinition[] = [
     labels: ['Feature:Logstash Pipelines'],
   },
   {
-    title: 'Machine Learning',
+    title: 'Agent Builder',
+    labels: ['Team:agent-builder', 'feature:agent-builder'],
+    priority: 20,
+  },
+  {
+    title: 'Machine learning and inference',
     labels: [
       ':ml',
+      'Team:AI Infra',
       'Feature:Anomaly Detection',
       'Feature:Data Frames',
       'Feature:File Data Viz',
@@ -176,6 +188,12 @@ export const kibanaAreas: AreaDefinition[] = [
       'Feature:Inference UI',
       'Feature:ML/AIOps',
     ],
+    priority: 10,
+  },
+  {
+    title: 'Workflows',
+    labels: ['Team:One Workflow'],
+    priority: 10,
   },
   {
     title: 'Maps',
@@ -240,7 +258,8 @@ export const kibanaAreas: AreaDefinition[] = [
   },
   {
     title: 'ES|QL',
-    labels: ['Team:ESQL'],
+    labels: ['Team:ESQL', 'Feature:ES|QL'],
+    priority: 10,
   },
   {
     title: 'Sharing and reporting',
@@ -254,6 +273,7 @@ export const kibanaAreas: AreaDefinition[] = [
   {
     title: 'Elastic Security solution',
     labels: securityLabels,
+    priority: 100,
     options: {
       textOverwriteTemplate:
         'For the Elastic Security {{version}} release information, refer to [Elastic Security Solution Release Notes](docs-content://release-notes/elastic-security/index.md).',
@@ -266,6 +286,7 @@ export const kibanaAreas: AreaDefinition[] = [
   {
     title: 'Elastic Observability solution',
     labels: observabilityLabels,
+    priority: 100,
     options: {
       textOverwriteTemplate:
         'For the Elastic Observability {{version}} release information, refer to [Elastic Observability Solution Release Notes](docs-content://release-notes/elastic-observability/index.md).',

--- a/src/config/templates/common.ts
+++ b/src/config/templates/common.ts
@@ -128,6 +128,7 @@ export const securityLabels = [
   'Feature:Detection Rules',
   'Feature:Detection Alerts',
   'Feature:Entity Analytics',
+  'Feature:Endpoint',
   'Feature:Rule Exceptions',
   'Feature:AutomaticImport',
   'Feature:Event Correlation (EQL) Rule',


### PR DESCRIPTION
## Summary

- add dedicated Agent Builder and Workflows areas, expand ES|QL routing, and rename Machine Learning to Machine learning and inference
- recognize missing Security and Observability labels while removing an unreliable CI-based Observability signal
- prioritize solution routing when labels overlap and add regression coverage for the affected mappings

Addresses #68

## Test plan

- [x] `yarn test --watchAll=false --watchman=false src/config/templates/common.test.ts`
- [x] `yarn build`
- [x] Prettier and TypeScript diagnostics pass for the changed files

Made with [Cursor](https://cursor.com)